### PR TITLE
Add game mode specific stats (Classic, Double Up, Assassins, Infection)

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -58,6 +58,12 @@ export default async function AdminHome() {
         >
           Minecraft crawl debug
         </Link>
+        <Link
+          href="/admin/tools/hypixel-crawl"
+          className="rounded-[3px] border-2 border-black/80 bg-slate-950/85 px-4 py-3 text-slate-100 hover:bg-slate-900/85 shadow-[0_0_0_1px_rgba(0,0,0,0.9),0_6px_0_0_rgba(0,0,0,0.9)]"
+        >
+          Hypixel stats crawler
+        </Link>
       </div>
     </main>
   );

--- a/src/app/api/cron/hypixel-crawl/page.tsx
+++ b/src/app/api/cron/hypixel-crawl/page.tsx
@@ -1,0 +1,59 @@
+// src/app/admin/tools/hypixel-crawl/page.tsx
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function HypixelCrawlPage() {
+  const [running, setRunning] = useState(false);
+  const [result, setResult] = useState<any>(null);
+
+  async function runCrawl() {
+    setRunning(true);
+    setResult(null);
+
+    try {
+      const response = await fetch("/api/cron/hypixel-crawl", {
+        headers: {
+          Authorization: `Bearer ${process.env.NEXT_PUBLIC_CRON_SECRET || ""}`,
+        },
+      });
+
+      const data = await response.json();
+      setResult(data);
+    } catch (error: any) {
+      setResult({ error: error.message });
+    } finally {
+      setRunning(false);
+    }
+  }
+
+  return (
+    <div className="container mx-auto p-6">
+      <h1 className="mb-6 text-3xl font-bold">Hypixel Stats Crawler</h1>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Manual Crawl Run</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="mb-4 text-sm text-gray-600">
+            Manually trigger a Hypixel stats update batch. Updates up to 40 players
+            with stale data (older than 24 hours).
+          </p>
+
+          <Button onClick={runCrawl} disabled={running}>
+            {running ? "Running..." : "Run Crawl Batch"}
+          </Button>
+
+          {result && (
+            <div className="mt-4 rounded bg-gray-100 p-4">
+              <pre className="text-xs">{JSON.stringify(result, null, 2)}</pre>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/api/cron/hypixel-crawl/route.ts
+++ b/src/app/api/cron/hypixel-crawl/route.ts
@@ -1,0 +1,44 @@
+// src/app/api/cron/hypixel-crawl/route.ts
+
+import { NextRequest, NextResponse } from "next/server";
+import { runHypixelCrawlBatch } from "@/lib/hypixel-crawl";
+
+/**
+ * Cron endpoint to automatically refresh Hypixel player snapshots.
+ * 
+ * Runs every 5 minutes via cron job.
+ * Updates ~40 players per run with 1100ms delay = ~270 req/5min
+ * SHOULD staay safely under Hypixel's 300 req/5min rate limit.
+ */
+export async function GET(req: NextRequest) {
+  // Verify cron secret to prevent unauthorized runs
+  const authHeader = req.headers.get("authorization");
+  const cronSecret = process.env.CRON_SECRET;
+
+  if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const result = await runHypixelCrawlBatch({
+      limit: 40,              // 40 entries per run
+      minAgeMinutes: 60 * 24, // Update entries older than 24 hours
+      sleepMs: 1100,          // 1.1s delay = ~54 req/min = 270 req/5min
+      logEvents: false,       // Don't spam logs in production
+    });
+
+    return NextResponse.json({
+      success: true,
+      runId: result.runId,
+      ran: result.ran,
+      summary: result.summary,
+      error: result.error,
+    });
+  } catch (error: any) {
+    console.error("[Hypixel Crawl Cron] Error:", error);
+    return NextResponse.json(
+      { error: error.message || "Unknown error" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/directory/_components/MMIDDirectoryMasterDetail.tsx
+++ b/src/app/directory/_components/MMIDDirectoryMasterDetail.tsx
@@ -1422,60 +1422,248 @@ https://example.com/screenshot"
               )}
             </div>
 
-            {/* Tab content – for now, show overall totals in a rich grid while we wire per-mode fields */}
-            <div className="mt-3 grid gap-3 text-[13px] sm:grid-cols-2 lg:grid-cols-3">
-              {/* Overall core */}
-              <div className="rounded-lg bg-black/40 px-3 py-2">
-                <div className="text-[10px] uppercase tracking-wide text-emerald-300/80">Overall</div>
-                <div className="mt-1 grid grid-cols-2 gap-x-3 gap-y-1">
-                  <div className="text-slate-300">Wins</div>
-                  <div className="text-right font-semibold text-emerald-200">{formatNum(stats.wins)}</div>
-                  <div className="text-slate-300">Kills</div>
-                  <div className="text-right font-semibold text-emerald-200">{formatNum(stats.kills)}</div>
-                  <div className="text-slate-300">Deaths</div>
-                  <div className="text-right font-semibold text-rose-200">{formatNum(stats.deaths)}</div>
-                  <div className="text-slate-300">KDR</div>
-                  <div className="text-right font-semibold text-orange-200">{formatKdr(stats.kdr)}</div>
-                  <div className="text-slate-300">Games played</div>
-                  <div className="text-right font-semibold text-sky-200">{formatNum(stats.gamesPlayed)}</div>
+            {/* Tab content - renders different stats based on active tab */}
+            {statsTab === "overall" && (
+              <div className="mt-3 grid gap-3 text-[13px] sm:grid-cols-2 lg:grid-cols-3">
+                {/* Overall core */}
+                <div className="rounded-lg bg-black/40 px-3 py-2">
+                  <div className="text-[10px] uppercase tracking-wide text-emerald-300/80">Overall</div>
+                  <div className="mt-1 grid grid-cols-2 gap-x-3 gap-y-1">
+                    <div className="text-slate-300">Wins</div>
+                    <div className="text-right font-semibold text-emerald-200">{formatNum(stats.wins)}</div>
+                    <div className="text-slate-300">Kills</div>
+                    <div className="text-right font-semibold text-emerald-200">{formatNum(stats.kills)}</div>
+                    <div className="text-slate-300">Deaths</div>
+                    <div className="text-right font-semibold text-rose-200">{formatNum(stats.deaths)}</div>
+                    <div className="text-slate-300">KDR</div>
+                    <div className="text-right font-semibold text-orange-200">{formatKdr(stats.kdr)}</div>
+                    <div className="text-slate-300">Games played</div>
+                    <div className="text-right font-semibold text-sky-200">{formatNum(stats.gamesPlayed)}</div>
+                  </div>
                 </div>
-              </div>
 
-              {/* Role wins / heroics */}
-              <div className="rounded-lg bg-black/40 px-3 py-2">
-                <div className="text-[10px] uppercase tracking-wide text-emerald-300/80">Role wins</div>
-                <div className="mt-1 grid grid-cols-2 gap-x-3 gap-y-1">
-                  <div className="text-slate-300">Murderer wins</div>
-                  <div className="text-right font-semibold text-rose-200">{formatNum(stats.murdererWins)}</div>
-                  <div className="text-slate-300">Detective wins</div>
-                  <div className="text-right font-semibold text-cyan-200">{formatNum(stats.detectiveWins)}</div>
-                  <div className="text-slate-300">Hero wins</div>
-                  <div className="text-right font-semibold text-yellow-200">{formatNum(stats.heroWins)}</div>
-                  <div className="text-slate-300">Suicides</div>
-                  <div className="text-right font-semibold text-rose-200">{formatNum(stats.suicides)}</div>
+                {/* Role wins / heroics */}
+                <div className="rounded-lg bg-black/40 px-3 py-2">
+                  <div className="text-[10px] uppercase tracking-wide text-emerald-300/80">Role wins</div>
+                  <div className="mt-1 grid grid-cols-2 gap-x-3 gap-y-1">
+                    <div className="text-slate-300">Murderer wins</div>
+                    <div className="text-right font-semibold text-rose-200">{formatNum(stats.murdererWins)}</div>
+                    <div className="text-slate-300">Detective wins</div>
+                    <div className="text-right font-semibold text-cyan-200">{formatNum(stats.detectiveWins)}</div>
+                    <div className="text-slate-300">Hero wins</div>
+                    <div className="text-right font-semibold text-yellow-200">{formatNum(stats.heroWins)}</div>
+                    <div className="text-slate-300">Suicides</div>
+                    <div className="text-right font-semibold text-rose-200">{formatNum(stats.suicides)}</div>
+                  </div>
                 </div>
-              </div>
 
-              {/* Kill breakdown */}
-              <div className="rounded-lg bg-black/40 px-3 py-2">
-                <div className="text-[10px] uppercase tracking-wide text-emerald-300/80">Kill breakdown</div>
-                <div className="mt-1 grid grid-cols-2 gap-x-3 gap-y-1">
-                  <div className="text-slate-300">Kills as murderer</div>
-                  <div className="text-right font-semibold text-rose-200">{formatNum(stats.killsAsMurderer)}</div>
-                  <div className="text-slate-300">Thrown knife kills</div>
-                  <div className="text-right font-semibold text-rose-200">{formatNum(stats.thrownKnifeKills)}</div>
-                  <div className="text-slate-300">Trap kills</div>
-                  <div className="text-right font-semibold text-amber-200">{formatNum(stats.trapKills)}</div>
-                  <div className="text-slate-300">Hero kills</div>
-                  <div className="text-right font-semibold text-sky-200">{formatNum(stats.heroKills)}</div>
-                  <div className="text-slate-300">Bow kills</div>
-                  <div className="text-right font-semibold text-emerald-200">{formatNum(stats.bowKillsTotal ?? stats.bowKills)}</div>
+                {/* Kill breakdown */}
+                <div className="rounded-lg bg-black/40 px-3 py-2">
+                  <div className="text-[10px] uppercase tracking-wide text-emerald-300/80">Kill breakdown</div>
+                  <div className="mt-1 grid grid-cols-2 gap-x-3 gap-y-1">
+                    <div className="text-slate-300">Kills as murderer</div>
+                    <div className="text-right font-semibold text-rose-200">{formatNum(stats.killsAsMurderer)}</div>
+                    <div className="text-slate-300">Thrown knife kills</div>
+                    <div className="text-right font-semibold text-rose-200">{formatNum(stats.thrownKnifeKills)}</div>
+                    <div className="text-slate-300">Trap kills</div>
+                    <div className="text-right font-semibold text-amber-200">{formatNum(stats.trapKills)}</div>
+                    <div className="text-slate-300">Bow kills</div>
+                    <div className="text-right font-semibold text-emerald-200">{formatNum(stats.bowKillsTotal ?? stats.bowKills)}</div>
+                  </div>
                 </div>
+              </div>                  
+            )}
+
+            {/* CLASSIC MODE TAB */}
+            {statsTab === "classic" && (
+              <div className="mt-3 grid gap-3 text-[13px] sm:grid-cols-2 lg:grid-cols-3">
+                {stats.classic ? (
+                  <>
+                    <div className="rounded-lg bg-black/40 px-3 py-2">
+                      <div className="text-[10px] uppercase tracking-wide text-emerald-300/80">Classic Mode</div>
+                      <div className="mt-1 grid grid-cols-2 gap-x-3 gap-y-1">
+                        <div className="text-slate-300">Wins</div>
+                        <div className="text-right font-semibold text-emerald-200">{formatNum(stats.classic.wins)}</div>
+                        <div className="text-slate-300">Kills</div>
+                        <div className="text-right font-semibold text-emerald-200">{formatNum(stats.classic.kills)}</div>
+                        <div className="text-slate-300">Deaths</div>
+                        <div className="text-right font-semibold text-rose-200">{formatNum(stats.classic.deaths)}</div>
+                        <div className="text-slate-300">KDR</div>
+                        <div className="text-right font-semibold text-orange-200">{formatKdr(stats.classic.kdr)}</div>
+                        <div className="text-slate-300">Games played</div>
+                        <div className="text-right font-semibold text-sky-200">{formatNum(stats.classic.gamesPlayed)}</div>
+                      </div>
+                    </div>
+
+                    <div className="rounded-lg bg-black/40 px-3 py-2">
+                      <div className="text-[10px] uppercase tracking-wide text-emerald-300/80">Role wins</div>
+                      <div className="mt-1 grid grid-cols-2 gap-x-3 gap-y-1">
+                        <div className="text-slate-300">Murderer wins</div>
+                        <div className="text-right font-semibold text-rose-200">{formatNum(stats.classic.murdererWins)}</div>
+                        <div className="text-slate-300">Detective wins</div>
+                        <div className="text-right font-semibold text-cyan-200">{formatNum(stats.classic.detectiveWins)}</div>
+                        <div className="text-slate-300">Hero wins</div>
+                        <div className="text-right font-semibold text-yellow-200">{formatNum(stats.classic.heroWins)}</div>
+                      </div>
+                    </div>
+
+                    <div className="rounded-lg bg-black/40 px-3 py-2">
+                      <div className="text-[10px] uppercase tracking-wide text-emerald-300/80">Kill breakdown</div>
+                      <div className="mt-1 grid grid-cols-2 gap-x-3 gap-y-1">
+                        <div className="text-slate-300">Kills as murderer</div>
+                        <div className="text-right font-semibold text-rose-200">{formatNum(stats.classic.killsAsMurderer)}</div>
+                        <div className="text-slate-300">Bow kills</div>
+                        <div className="text-right font-semibold text-emerald-200">{formatNum(stats.classic.bowKills)}</div>
+                        <div className="text-slate-300">Trap kills</div>
+                        <div className="text-right font-semibold text-amber-200">{formatNum(stats.classic.trapKills)}</div>
+                        <div className="text-slate-300">Thrown knife kills</div>
+                        <div className="text-right font-semibold text-rose-200">{formatNum(stats.classic.thrownKnifeKills)}</div>
+                      </div>
+                    </div>
+                  </>
+                ) : (
+                  <div className="col-span-full rounded-lg border border-dashed border-emerald-500/30 bg-black/20 p-6 text-center">
+                    <p className="text-sm text-slate-300">No Classic mode data available for this player.</p>
+                    <p className="mt-1 text-[11px] text-slate-400">They may not have played this mode yet.</p>
+                  </div>
+                )}
               </div>
-            </div>
-          </>
-        )}
-      </div>
+            )}
+
+            {/* DOUBLE UP MODE TAB */}
+            {statsTab === "double" && (
+              <div className="mt-3 grid gap-3 text-[13px] sm:grid-cols-2 lg:grid-cols-3">
+                {stats.doubleUp ? (
+                  <>
+                    <div className="rounded-lg bg-black/40 px-3 py-2">
+                      <div className="text-[10px] uppercase tracking-wide text-emerald-300/80">Double Up Mode</div>
+                      <div className="mt-1 grid grid-cols-2 gap-x-3 gap-y-1">
+                        <div className="text-slate-300">Wins</div>
+                        <div className="text-right font-semibold text-emerald-200">{formatNum(stats.doubleUp.wins)}</div>
+                        <div className="text-slate-300">Kills</div>
+                        <div className="text-right font-semibold text-emerald-200">{formatNum(stats.doubleUp.kills)}</div>
+                        <div className="text-slate-300">Deaths</div>
+                        <div className="text-right font-semibold text-rose-200">{formatNum(stats.doubleUp.deaths)}</div>
+                        <div className="text-slate-300">KDR</div>
+                        <div className="text-right font-semibold text-orange-200">{formatKdr(stats.doubleUp.kdr)}</div>
+                        <div className="text-slate-300">Games played</div>
+                        <div className="text-right font-semibold text-sky-200">{formatNum(stats.doubleUp.gamesPlayed)}</div>
+                      </div>
+                    </div>
+
+                    <div className="rounded-lg bg-black/40 px-3 py-2">
+                      <div className="text-[10px] uppercase tracking-wide text-emerald-300/80">Role wins</div>
+                      <div className="mt-1 grid grid-cols-2 gap-x-3 gap-y-1">
+                        <div className="text-slate-300">Murderer wins</div>
+                        <div className="text-right font-semibold text-rose-200">{formatNum(stats.doubleUp.murdererWins)}</div>
+                        <div className="text-slate-300">Detective wins</div>
+                        <div className="text-right font-semibold text-cyan-200">{formatNum(stats.doubleUp.detectiveWins)}</div>
+                        <div className="text-slate-300">Hero wins</div>
+                        <div className="text-right font-semibold text-yellow-200">{formatNum(stats.doubleUp.heroWins)}</div>
+                      </div>
+                    </div>
+
+                    <div className="rounded-lg bg-black/40 px-3 py-2">
+                      <div className="text-[10px] uppercase tracking-wide text-emerald-300/80">Kill breakdown</div>
+                      <div className="mt-1 grid grid-cols-2 gap-x-3 gap-y-1">
+                        <div className="text-slate-300">Kills as murderer</div>
+                        <div className="text-right font-semibold text-rose-200">{formatNum(stats.doubleUp.killsAsMurderer)}</div>
+                        <div className="text-slate-300">Bow kills</div>
+                        <div className="text-right font-semibold text-emerald-200">{formatNum(stats.doubleUp.bowKills)}</div>
+                        <div className="text-slate-300">Trap kills</div>
+                        <div className="text-right font-semibold text-amber-200">{formatNum(stats.doubleUp.trapKills)}</div>
+                        <div className="text-slate-300">Thrown knife kills</div>
+                        <div className="text-right font-semibold text-rose-200">{formatNum(stats.doubleUp.thrownKnifeKills)}</div>
+
+                      </div>
+                    </div>
+                  </>
+                ) : (
+                  <div className="col-span-full rounded-lg border border-dashed border-emerald-500/30 bg-black/20 p-6 text-center">
+                    <p className="text-sm text-slate-300">No Double Up mode data available for this player.</p>
+                    <p className="mt-1 text-[11px] text-slate-400">They may not have played this mode yet.</p>
+                  </div>
+                )}
+              </div>
+            )}
+
+            {/* ASSASSINS MODE TAB */}
+            {statsTab === "assassins" && (
+              <div className="mt-3 grid gap-3 text-[13px] sm:grid-cols-2 lg:grid-cols-3">
+                {stats.assassins ? (
+                  <>
+                    <div className="rounded-lg bg-black/40 px-3 py-2">
+                      <div className="text-[10px] uppercase tracking-wide text-purple-300/80">Assassins</div>
+                      <div className="mt-1 grid grid-cols-2 gap-x-3 gap-y-1">
+                        <div className="text-slate-300">Wins</div>
+                        <div className="text-right font-semibold text-emerald-200">{formatNum(stats.assassins.wins)}</div>
+                        <div className="text-slate-300">Kills</div>
+                        <div className="text-right font-semibold text-emerald-200">{formatNum(stats.assassins.kills)}</div>
+                        <div className="text-slate-300">Deaths</div>
+                        <div className="text-right font-semibold text-rose-200">{formatNum(stats.assassins.deaths)}</div>
+                        <div className="text-slate-300">KDR</div>
+                        <div className="text-right font-semibold text-orange-200">{formatKdr(stats.assassins.kdr)}</div>
+                      </div>
+                    </div>
+
+                    <div className="rounded-lg bg-black/40 px-3 py-2">
+                      <div className="text-[10px] uppercase tracking-wide text-purple-300/80">Other Stats</div>
+                      <div className="mt-1 grid grid-cols-2 gap-x-3 gap-y-1">
+                        <div className="text-slate-300">Games played</div>
+                        <div className="text-right font-semibold text-sky-200">{formatNum(stats.assassins.gamesPlayed)}</div>
+                        <div className="text-slate-300">Coins</div>
+                        <div className="text-right font-semibold text-yellow-200">{formatNum(stats.assassins.coins)}</div>
+                      </div>
+                    </div>
+                  </>
+                ) : (
+                  <div className="col-span-full rounded-lg border border-dashed border-purple-500/30 bg-black/20 p-6 text-center">
+                    <p className="text-sm text-slate-300">No Assassins mode data available for this player.</p>
+                    <p className="mt-1 text-[11px] text-slate-400">They may not have played this mode yet.</p>
+                  </div>
+                )}
+              </div>
+            )}
+
+            {/* INFECTION MODE TAB */}
+            {statsTab === "infection" && (
+              <div className="mt-3 grid gap-3 text-[13px] sm:grid-cols-2 lg:grid-cols-3">
+                {stats.infection ? (
+                  <>
+                    <div className="rounded-lg bg-black/40 px-3 py-2">
+                      <div className="text-[10px] uppercase tracking-wide text-red-300/80">Infection</div>
+                      <div className="mt-1 grid grid-cols-2 gap-x-3 gap-y-1">
+                        <div className="text-slate-300">Total wins</div>
+                        <div className="text-right font-semibold text-emerald-200">{formatNum(stats.infection.wins)}</div>
+                        <div className="text-slate-300">Kills</div>
+                        <div className="text-right font-semibold text-emerald-200">{formatNum(stats.infection.kills)}</div>
+                        <div className="text-slate-300">Deaths</div>
+                        <div className="text-right font-semibold text-rose-200">{formatNum(stats.infection.deaths)}</div>
+                        <div className="text-slate-300">Games played</div>
+                        <div className="text-right font-semibold text-sky-200">{formatNum(stats.infection.gamesPlayed)}</div>
+                      </div>
+                    </div>
+
+                    <div className="rounded-lg bg-black/40 px-3 py-2">
+                      <div className="text-[10px] uppercase tracking-wide text-red-300/80">Wins by role</div>
+                      <div className="mt-1 grid grid-cols-2 gap-x-3 gap-y-1">
+                        <div className="text-slate-300">Survivor wins</div>
+                        <div className="text-right font-semibold text-cyan-200">{formatNum(stats.infection.survivorWins)}</div>
+                        <div className="text-slate-300">Infected wins</div>
+                        <div className="text-right font-semibold text-rose-200">{formatNum(stats.infection.infectedWins)}</div>
+                      </div>
+                    </div>
+                  </>
+                ) : (
+                  <div className="col-span-full rounded-lg border border-dashed border-red-500/30 bg-black/20 p-6 text-center">
+                    <p className="text-sm text-slate-300">No Infection mode data available for this player.</p>
+                    <p className="mt-1 text-[11px] text-slate-400">They may not have played this mode yet.</p>
+                  </div>
+                )}
+              </div>
+            )}
+        
+      
 
       {/* Bottom row: Username history + Alt Accounts side by side */}
       {(!canEdit || !editMode) && (
@@ -1531,10 +1719,13 @@ https://example.com/screenshot"
         </div>
       </div>
       )}
-
+        </>
+        )}
+      </div>
     </div>
   );
 }
+
 
 /* ---------------------------------------------
    Master/detail layout with right-hand directory

--- a/src/lib/hypixel-crawl.ts
+++ b/src/lib/hypixel-crawl.ts
@@ -1,0 +1,239 @@
+// src/lib/hypixel-crawl.ts
+
+import { prisma } from "@/lib/prisma";
+import { withPgAdvisoryLock } from "@/lib/lock";
+import { refreshPlayerSnapshotFromHypixel } from "@/lib/hypixel-player-stats";
+
+function clamp(n: number, min: number, max: number) {
+  return Math.max(min, Math.min(max, n));
+}
+
+function normalizeUuid(uuid: string) {
+  return uuid.replace(/-/g, "").toLowerCase();
+}
+
+function sleep(ms: number) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+export type HypixelCrawlBatchParams = {
+  limit?: number;
+  minAgeMinutes?: number;
+  sleepMs?: number;
+
+  /**
+   * When true, store detailed per-player events in HypixelCrawlRunEvent.
+   * Keep this off for scheduled cron runs to avoid unbounded log growth.
+   */
+  logEvents?: boolean;
+
+  /**
+   * Optional event hook for live dashboards.
+   * Called for the same events that may be persisted when logEvents is true.
+   */
+  onEvent?: (evt: HypixelCrawlEvent) => void | Promise<void>;
+};
+
+export type HypixelCrawlEvent = {
+  level: "info" | "warn" | "error";
+  eventType:
+    | "run_started"
+    | "player_started"
+    | "snapshot_saved"
+    | "player_error"
+    | "run_finished";
+  runId: string;
+  uuid?: string;
+  username?: string;
+  message?: string;
+  meta?: any;
+  createdAt: string;
+};
+
+export type HypixelCrawlBatchSummary = {
+  limit: number;
+  minAgeMinutes: number;
+  sleepMs: number;
+  cutoff: string;
+  candidates: number;
+  processed: number;
+  snapshotted: number;
+  errors: number;
+};
+
+export async function getHypixelCrawlQueueSize(minAgeMinutes: number): Promise<number> {
+  const cutoff = new Date(Date.now() - minAgeMinutes * 60 * 1000);
+
+  const latestSnapshots = await prisma.hypixelPlayerSnapshot.groupBy({
+    by: ["uuid"],
+    _max: { fetchedAt: true },
+  });
+
+  const lastByUuid = new Map<string, Date>();
+  for (const row of latestSnapshots) {
+    if (row._max.fetchedAt) lastByUuid.set(row.uuid, row._max.fetchedAt);
+  }
+
+  const entries = await prisma.mmidEntry.findMany({
+    select: { uuid: true },
+  });
+
+  let count = 0;
+  for (const e of entries) {
+    const norm = normalizeUuid(e.uuid);
+    const last = lastByUuid.get(norm) ?? null;
+    if (!last || last < cutoff) count += 1;
+  }
+
+  return count;
+}
+
+export async function runHypixelCrawlBatch(
+  params: HypixelCrawlBatchParams = {},
+): Promise<{ runId: string; ran: boolean; summary?: HypixelCrawlBatchSummary; error?: string }> {
+  // Keep each run bounded so it works in serverless environments.
+  const limit = clamp(Math.trunc(params.limit ?? 40), 1, 250);
+  const minAgeMinutes = clamp(Math.trunc(params.minAgeMinutes ?? 60 * 24), 1, 60 * 24 * 30);
+  const sleepMs = clamp(Math.trunc(params.sleepMs ?? 1100), 0, 5000);
+
+  const logEvents = Boolean(params.logEvents);
+
+  // Create a mock run record (you can create a proper HypixelCrawlRun model if needed)
+  const runId = `hypixel-crawl-${Date.now()}`;
+
+  const emit = async (partial: Omit<HypixelCrawlEvent, "runId" | "createdAt">) => {
+    const evt: HypixelCrawlEvent = {
+      runId,
+      createdAt: new Date().toISOString(),
+      ...partial,
+    };
+
+    try {
+      await params.onEvent?.(evt);
+    } catch {
+      // ignore
+    }
+
+    if (logEvents) {
+      console.log(`[Hypixel Crawl] [${evt.level}] ${evt.eventType}: ${evt.message}`);
+    }
+  };
+
+  await emit({ level: "info", eventType: "run_started", message: "Hypixel crawl run started" });
+
+  try {
+    const cutoff = new Date(Date.now() - minAgeMinutes * 60 * 1000);
+
+    // One crawler at a time across deployments.
+    const lock = await withPgAdvisoryLock({ key1: 44874, key2: 1 }, async () => {
+      // 1) Figure out latest snapshot time per UUID
+      const latestSnapshots = await prisma.hypixelPlayerSnapshot.groupBy({
+        by: ["uuid"],
+        _max: { fetchedAt: true },
+      });
+
+      const lastByUuid = new Map<string, Date>();
+      for (const row of latestSnapshots) {
+        if (row._max.fetchedAt) lastByUuid.set(row.uuid, row._max.fetchedAt);
+      }
+
+      // 2) Prioritize entries with missing/old snapshots.
+      const entries = await prisma.mmidEntry.findMany({
+        select: { uuid: true, username: true },
+        orderBy: { username: "asc" },
+      });
+
+      const candidates = entries
+        .map((e) => {
+          const norm = normalizeUuid(e.uuid);
+          const last = lastByUuid.get(norm) ?? null;
+          return { ...e, norm, last };
+        })
+        .filter((e) => !e.last || e.last < cutoff)
+        .sort((a, b) => {
+          const ta = a.last ? a.last.getTime() : 0;
+          const tb = b.last ? b.last.getTime() : 0;
+          return ta - tb;
+        })
+        .slice(0, limit);
+
+      let processed = 0;
+      let snapshotted = 0;
+      let errors = 0;
+
+      for (const e of candidates) {
+        processed += 1;
+
+        await emit({
+          level: "info",
+          eventType: "player_started",
+          uuid: e.uuid,
+          username: e.username,
+          message: `Processing ${e.username}`,
+        });
+
+        try {
+          // Refresh Hypixel player snapshot
+          const snapshot = await refreshPlayerSnapshotFromHypixel(e.uuid);
+          snapshotted += 1;
+
+          await emit({
+            level: "info",
+            eventType: "snapshot_saved",
+            uuid: e.uuid,
+            username: e.username,
+            message: `Snapshot saved for ${e.username}`,
+            meta: {
+              fetchedAt: snapshot.fetchedAt?.toISOString?.() ?? undefined,
+            },
+          });
+        } catch (err: any) {
+          errors += 1;
+          console.error("Hypixel crawl failed for", e.uuid, err);
+
+          await emit({
+            level: "error",
+            eventType: "player_error",
+            uuid: e.uuid,
+            username: e.username,
+            message: err?.message ?? "player crawl failed",
+          });
+        }
+
+        if (sleepMs > 0) await sleep(sleepMs);
+      }
+
+      const summary: HypixelCrawlBatchSummary = {
+        limit,
+        minAgeMinutes,
+        sleepMs,
+        cutoff: cutoff.toISOString(),
+        candidates: candidates.length,
+        processed,
+        snapshotted,
+        errors,
+      };
+
+      return summary;
+    });
+
+    if (!lock.ran) {
+      await emit({ level: "warn", eventType: "run_finished", message: "Crawler already running" });
+      return { runId, ran: false, error: "Crawler already running" };
+    }
+
+    const summary = lock.value!;
+
+    await emit({
+      level: summary.errors > 0 ? "warn" : "info",
+      eventType: "run_finished",
+      message: `Run finished: processed=${summary.processed}, snapshotted=${summary.snapshotted}, errors=${summary.errors}`,
+      meta: summary,
+    });
+
+    return { runId, ran: true, summary };
+  } catch (err: any) {
+    await emit({ level: "error", eventType: "run_finished", message: err?.message ?? "Hypixel crawl failed" });
+    return { runId, ran: false, error: err?.message ?? "Hypixel crawl failed" };
+  }
+}

--- a/src/lib/hypixel-player-stats.ts
+++ b/src/lib/hypixel-player-stats.ts
@@ -1,23 +1,26 @@
 // src/lib/hypixel-player-stats.ts
 //
+// Updated version with Classic, Double Up, Assassins, Infection stats
+//
 // Thin helper around the Hypixel /player + /guild endpoints that:
 // - extracts the Murder Mystery stats we care about for MMID
+// - extracts the rest of the game modes (Assassins, Infection)
 // - caches the raw payloads + derived stats in Prisma
 // - exposes a small, stable shape for the directory to consume
-//
-// This is intentionally conservative about freshness: we treat any
-// snapshot newer than SNAPSHOT_TTL_MS as fresh and never re-fetch
-// automatically from the directory page. Maintainers can force a
-// refresh via the existing "Hypixel" button on each directory card.
 
 import { prisma } from "@/lib/prisma";
 import { hypixelFetchJson } from "@/lib/hypixel-client";
 import { withPgAdvisoryLock } from "@/lib/lock";
 
-const SNAPSHOT_TTL_MS = 5 * 60 * 1000; // 5 minutes
+// const SNAPSHOT_TTL_MS = 5 * 60 * 1000; // 5 minutes
+const SNAPSHOT_TTL_MS = 0;
 
-export type DirectoryMmStats = {
-  // Murder Mystery overall stats used by the MMID card.
+// ============================================================================
+// TYPE DEFINITIONS
+// ============================================================================
+
+/** Murder Mystery overall stats used by the MMID card. */
+export type MurderMysteryStats = {
   wins?: number | null;
   kills?: number | null;
   deaths?: number | null;
@@ -32,7 +35,7 @@ export type DirectoryMmStats = {
   bowKills?: number | null;
   thrownKnifeKills?: number | null;
   trapKills?: number | null;
-  heroKills?: number | null;
+  // heroKills?: number | null;
 
   bowKillsTotal?: number | null;
   suicides?: number | null;
@@ -40,11 +43,90 @@ export type DirectoryMmStats = {
   tokens?: number | null;
   goldPickedUp?: number | null;
 
-  /**
-   * Currently equipped Murder Mystery knife skin, as reported by Hypixel.
-   * This comes from stats.MurderMystery.active_knife_skin and looks like
-   * "knife_skin_shears", "knife_skin_rudolphs_snack", etc.
-   */
+  equippedKnifeSkin?: string | null;
+};
+
+/** Murder Mystery Classic mode specific stats */
+export type MurderMysteryClassicStats = {
+  wins?: number | null;
+  kills?: number | null;
+  deaths?: number | null;
+  kdr?: number | null;
+  gamesPlayed?: number | null;
+  
+  murdererWins?: number | null;
+  detectiveWins?: number | null;
+  heroWins?: number | null;
+  
+  killsAsMurderer?: number | null;
+  trapKills?: number | null;
+  bowKills?: number | null;
+  thrownKnifeKills?: number | null;
+};
+
+/** Murder Mystery Double Up mode specific stats */
+export type MurderMysteryDoubleUpStats = {
+  wins?: number | null;
+  kills?: number | null;
+  deaths?: number | null;
+  kdr?: number | null;
+  gamesPlayed?: number | null;
+  
+  murdererWins?: number | null;
+  detectiveWins?: number | null;
+  heroWins?: number | null;
+  
+  killsAsMurderer?: number | null;
+  bowKills?: number | null;
+  trapKills?: number | null;
+  thrownKnifeKills?: number | null;
+};
+
+/** Assassins game mode stats */
+export type AssassinsStats = {
+  kills?: number | null;
+  deaths?: number | null;
+  kdr?: number | null;
+  wins?: number | null;
+  gamesPlayed?: number | null;
+  coins?: number | null;
+};
+
+/** Infection game mode stats */
+export type InfectionStats = {
+  kills?: number | null;
+  deaths?: number | null;
+  wins?: number | null;
+  survivorWins?: number | null;
+  infectedWins?: number | null;
+  gamesPlayed?: number | null;
+};
+
+/** Complete stats for directory display */
+export type DirectoryMmStats = {
+  // Overall Murder Mystery stats (existing)
+  wins?: number | null;
+  kills?: number | null;
+  deaths?: number | null;
+  kdr?: number | null;
+  gamesPlayed?: number | null;
+
+  murdererWins?: number | null;
+  detectiveWins?: number | null;
+  heroWins?: number | null;
+
+  killsAsMurderer?: number | null;
+  bowKills?: number | null;
+  thrownKnifeKills?: number | null;
+  trapKills?: number | null;
+  // heroKills?: number | null;
+
+  bowKillsTotal?: number | null;
+  suicides?: number | null;
+
+  tokens?: number | null;
+  goldPickedUp?: number | null;
+
   equippedKnifeSkin?: string | null;
 
   // Global Hypixel profile info we surface in the MMID panel.
@@ -59,17 +141,26 @@ export type DirectoryMmStats = {
   challengesCompleted?: number | null;
   giftsSent?: number | null;
   ranksGifted?: number | null;
-  firstLogin?: number | null; // unix ms
-  lastLogin?: number | null;  // unix ms
+  firstLogin?: number | null;
+  lastLogin?: number | null;
 
-  /** Optional guild tag, e.g. "MMID" (without brackets). */
   guildTag?: string | null;
-
-  /** Optional guild name colour from Hypixel guild data (e.g. "RED", "GOLD"). */
   guildColor?: string | null;
-
-  /** Optional rank plus colour from Hypixel (e.g. "RED", "GOLD"). */
   rankPlusColor?: string | null;
+
+  // ===== MORE GAME MODES =====
+  
+  /** Murder Mystery Classic mode breakdown */
+  classic?: MurderMysteryClassicStats | null;
+  
+  /** Murder Mystery Double Up mode breakdown */
+  doubleUp?: MurderMysteryDoubleUpStats | null;
+  
+  /** Assassins mode stats */
+  assassins?: AssassinsStats | null;
+  
+  /** Infection mode stats */
+  infection?: InfectionStats | null;
 };
 
 export type DirectoryPlayerSnapshot = {
@@ -78,19 +169,22 @@ export type DirectoryPlayerSnapshot = {
   fetchedAt: Date;
 };
 
-// Hypixel uses nested stats under `stats.MurderMystery`. We only
-// extract a curated subset that is generally meaningful across modes
-// and matches the MMID stats card.
-function extractMmStatsFromPlayer(player: any): DirectoryMmStats | null {
-  if (!player || typeof player !== "object") return null;
-  const mm = (player.stats && player.stats.MurderMystery) || undefined;
-  if (!mm || typeof mm !== "object") return null;
+// ============================================================================
+// EXTRACTION FUNCTIONS
+// ============================================================================
 
-  const num = (v: unknown): number | null => {
-    const n = Number(v);
-    return Number.isFinite(n) ? n : null;
-  };
+/**
+ * Helper: safely parse a number from unknown value
+ */
+function num(v: unknown): number | null {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+}
 
+/**
+ * Extract overall Murder Mystery stats from Hypixel player data
+ */
+function extractOverallMmStats(mm: any): MurderMysteryStats {
   const wins = num(mm.wins || mm.overall_wins);
   const kills = num(mm.kills || mm.overall_kills);
   const deaths = num(mm.deaths || mm.overall_deaths);
@@ -98,38 +192,230 @@ function extractMmStatsFromPlayer(player: any): DirectoryMmStats | null {
 
   const murdererWins = num(mm.murderer_wins || mm.wins_as_murderer);
   const detectiveWins = num(mm.detective_wins || mm.wins_as_detective);
-  const heroWins = num(mm.hero_wins);
+  const heroWins = num(mm.was_hero);
 
-  // Hypixel has used multiple field names over time. In particular:
-  // - some payloads report "knife_kills" instead of "kills_as_murderer" / "murderer_kills"
-  // - thrown knife kills are usually "thrown_knife_kills"
   const killsAsMurderer = num(mm.kills_as_murderer || mm.murderer_kills || mm.knife_kills);
   const bowKills = num(mm.bow_kills || mm.bow_kills_murderer);
   const thrownKnifeKills = num(mm.thrown_knife_kills);
   const trapKills = num(mm.trap_kills);
-  const heroKills = num(mm.hero_kills);
+  // const heroKills = num(mm.was_hero);
 
   const bowKillsTotal = num(mm.bow_kills_total || mm.bow_kills);
   const suicides = num(mm.suicides);
 
   const tokens = num(mm.tokens || mm.coins);
-
-  // Hypixel sometimes exposes "coins_pickedup" rather than a dedicated gold counter.
-  // We treat this as the best available proxy for "gold picked up" in the UI.
   const goldPickedUp = num(
     mm.gold_picked_up ||
-      mm.gold_picked_up_total ||
-      mm.coins_pickedup ||
-      mm.coins_picked_up,
+    mm.gold_picked_up_total ||
+    mm.coins_pickedup ||
+    mm.coins_picked_up,
   );
 
   const equippedKnifeSkin = typeof mm.active_knife_skin === "string" ? mm.active_knife_skin : null;
+
+  const kdr = kills != null && deaths != null && deaths > 0 ? Number((kills / deaths).toFixed(2)) : null;
+
+  return {
+    wins,
+    kills,
+    deaths,
+    kdr,
+    gamesPlayed,
+    murdererWins,
+    detectiveWins,
+    heroWins,
+    killsAsMurderer,
+    bowKills,
+    thrownKnifeKills,
+    trapKills,
+    // heroKills,
+    bowKillsTotal,
+    suicides,
+    tokens,
+    goldPickedUp,
+    equippedKnifeSkin,
+  };
+}
+
+/**
+ * Extract Murder Mystery CLASSIC mode stats
+ * Hypixel uses prefixes like "wins_MURDER_CLASSIC", "kills_MURDER_CLASSIC", etc.
+ */
+function extractClassicStats(mm: any): MurderMysteryClassicStats | null {
+  if (!mm || typeof mm !== "object") return null;
+
+  const wins = num(mm.wins_MURDER_CLASSIC);
+  const kills = num(mm.kills_MURDER_CLASSIC);
+  const deaths = num(mm.deaths_MURDER_CLASSIC);
+  const gamesPlayed = num(mm.games_MURDER_CLASSIC);
+  
+  const murdererWins = num(mm.murderer_wins_MURDER_CLASSIC);
+  const detectiveWins = num(mm.detective_wins_MURDER_CLASSIC);
+  const heroWins = num(mm.was_hero_MURDER_CLASSIC);
+  
+  const killsAsMurderer = num(mm.kills_as_murderer_MURDER_CLASSIC || mm.knife_kills_MURDER_CLASSIC);
+  const trapKills = num(mm.trap_kills_MURDER_CLASSIC);
+  const bowKills = num(mm.bow_kills_MURDER_CLASSIC);
+  const thrownKnifeKills = num(mm.thrown_knife_kills_MURDER_CLASSIC);
+
+  const kdr = kills != null && deaths != null && deaths > 0 
+    ? Number((kills / deaths).toFixed(2)) 
+    : null;
+
+  // If no data, return null
+  const hasData = wins != null || kills != null || deaths != null || gamesPlayed != null;
+  if (!hasData) return null;
+
+  return {
+    wins,
+    kills,
+    deaths,
+    kdr,
+    gamesPlayed,
+    murdererWins,
+    detectiveWins,
+    heroWins,
+    killsAsMurderer,
+    trapKills,
+    bowKills,
+    thrownKnifeKills,
+  };
+}
+
+/**
+ * Extract Murder Mystery DOUBLE UP mode stats
+ * Hypixel uses prefixes like "wins_MURDER_DOUBLE_UP", "kills_MURDER_DOUBLE_UP", etc.
+ */
+function extractDoubleUpStats(mm: any): MurderMysteryDoubleUpStats | null {
+  if (!mm || typeof mm !== "object") return null;
+
+  const wins = num(mm.wins_MURDER_DOUBLE_UP);
+  const kills = num(mm.kills_MURDER_DOUBLE_UP);
+  const deaths = num(mm.deaths_MURDER_DOUBLE_UP);
+  const gamesPlayed = num(mm.games_MURDER_DOUBLE_UP);
+  
+  const murdererWins = num(mm.murderer_wins_MURDER_DOUBLE_UP);
+  const detectiveWins = num(mm.detective_wins_MURDER_DOUBLE_UP);
+  const heroWins = num(mm.was_hero_MURDER_DOUBLE_UP);
+
+  
+  const killsAsMurderer = num(mm.kills_as_murderer_MURDER_DOUBLE_UP || mm.knife_kills_MURDER_DOUBLE_UP);
+  const bowKills = num(mm.bow_kills_MURDER_DOUBLE_UP);
+  const trapKills = num(mm.trap_kills_MURDER_DOUBLE_UP);
+  const thrownKnifeKills = num(mm.thrown_knife_kills_MURDER_DOUBLE_UP);
+
+  const kdr = kills != null && deaths != null && deaths > 0 
+    ? Number((kills / deaths).toFixed(2)) 
+    : null;
+
+  const hasData = wins != null || kills != null || deaths != null || gamesPlayed != null;
+  if (!hasData) return null;
+
+  return {
+    wins,
+    kills,
+    deaths,
+    kdr,
+    gamesPlayed,
+    murdererWins,
+    detectiveWins,
+    killsAsMurderer,
+    bowKills,
+    trapKills,
+    heroWins,
+    thrownKnifeKills
+  };
+}
+
+/**
+ * Extract Murder Mystery ASSASSINS mode stats
+ * Hypixel uses prefixes like "wins_MURDER_ASSASSINS", etc.
+ */
+function extractAssassinsStats(mm: any): AssassinsStats | null {
+  if (!mm || typeof mm !== "object") return null;
+
+  const wins = num(mm.wins_MURDER_ASSASSINS);
+  const kills = num(mm.kills_MURDER_ASSASSINS);
+  const deaths = num(mm.deaths_MURDER_ASSASSINS);
+  const gamesPlayed = num(mm.games_MURDER_ASSASSINS);
+  const coins = num(mm.coins_MURDER_ASSASSINS);
+
+  const kdr =
+    kills != null && deaths != null && deaths > 0
+      ? Number((kills / deaths).toFixed(2))
+      : null;
+
+  const hasData =
+    wins != null || kills != null || deaths != null || gamesPlayed != null;
+
+  if (!hasData) return null;
+
+  return {
+    wins,
+    kills,
+    deaths,
+    kdr,
+    gamesPlayed,
+    coins,
+  };
+}
+
+
+/**
+ * Extract Murder Mystery INFECTION mode stats
+ * Hypixel uses prefixes like "wins_MURDER_INFECTION", etc.
+ */
+function extractInfectionStats(mm: any): InfectionStats | null {
+  if (!mm || typeof mm !== "object") return null;
+
+  const wins = num(mm.wins_MURDER_INFECTION);
+  const kills = num(mm.kills_MURDER_INFECTION);
+  const deaths = num(mm.deaths_MURDER_INFECTION);
+  const gamesPlayed = num(mm.games_MURDER_INFECTION);
+
+  const survivorWins = num(mm.survivor_wins_MURDER_INFECTION);
+  const infectedWins = num(mm.infected_wins_MURDER_INFECTION);
+
+  const hasData =
+    wins != null || kills != null || deaths != null || gamesPlayed != null;
+
+  if (!hasData) return null;
+
+  return {
+    wins,
+    kills,
+    deaths,
+    survivorWins,
+    infectedWins,
+    gamesPlayed,
+  };
+}
+
+
+/**
+ * Main extraction function that combines ALL game modes
+ */
+function extractMmStatsFromPlayer(player: any): DirectoryMmStats | null {
+  if (!player || typeof player !== "object") return null;
+  
+  const mm = (player.stats && player.stats.MurderMystery) || undefined;
+
+  
+  if (!mm || typeof mm !== "object") return null;
+
+  // Extract overall MM stats (existing code)
+  const overallStats = extractOverallMmStats(mm);
+
+  // Extract mode-specific stats
+  const classic = extractClassicStats(mm);
+  const doubleUp = extractDoubleUpStats(mm);
+  const assassins = extractAssassinsStats(mm);
+  const infection = extractInfectionStats(mm);
 
   // Global profile fields live directly on the player object.
   const networkExp = num((player as any).networkExp);
   let networkLevel: number | null = null;
   if (networkExp != null) {
-    // Official Hypixel network level formula.
     const raw = Math.sqrt(2 * networkExp + 30625) / 50 - 2.5;
     networkLevel = Number(raw.toFixed(2));
   }
@@ -152,7 +438,7 @@ function extractMmStatsFromPlayer(player: any): DirectoryMmStats | null {
     questsCompleted = total;
   }
 
-  // Challenges: some payloads expose an all_time map of challenge -> count.
+  // Challenges
   let challengesCompleted: number | null = null;
   const challenges = (player as any).challenges;
   if (challenges && typeof challenges === "object" && (challenges as any).all_time) {
@@ -165,7 +451,7 @@ function extractMmStatsFromPlayer(player: any): DirectoryMmStats | null {
     challengesCompleted = totalC;
   }
 
-  // Gifting metadata.
+  // Gifting metadata
   let giftsSent: number | null = null;
   let ranksGifted: number | null = null;
   const giftingMeta = (player as any).giftingMeta;
@@ -180,27 +466,8 @@ function extractMmStatsFromPlayer(player: any): DirectoryMmStats | null {
   const rankPlusColorRaw = (player as any).rankPlusColor || (player as any).monthlyRankColor;
   const rankPlusColor = typeof rankPlusColorRaw === "string" ? rankPlusColorRaw : null;
 
-  const kdr = kills != null && deaths != null && deaths > 0 ? Number((kills / deaths).toFixed(2)) : null;
-
   return {
-    wins,
-    kills,
-    deaths,
-    kdr,
-    gamesPlayed,
-    murdererWins,
-    detectiveWins,
-    heroWins,
-    killsAsMurderer,
-    bowKills,
-    thrownKnifeKills,
-    trapKills,
-    heroKills,
-    bowKillsTotal,
-    suicides,
-    tokens,
-    goldPickedUp,
-    equippedKnifeSkin,
+    ...overallStats,
     networkExp,
     networkLevel,
     achievementPoints,
@@ -215,8 +482,18 @@ function extractMmStatsFromPlayer(player: any): DirectoryMmStats | null {
     firstLogin,
     lastLogin,
     rankPlusColor,
+    
+    // MODE-SPECIFIC STATS
+    classic,
+    doubleUp,
+    assassins,
+    infection,
   };
 }
+
+// ============================================================================
+// DATABASE OPERATIONS 
+// ============================================================================
 
 function normalizeUuid(raw: string): string {
   return raw.replace(/-/g, "").toLowerCase();
@@ -228,8 +505,6 @@ export async function getCachedPlayerSnapshot(uuidRaw: string): Promise<Director
   if (!row) return null;
 
   const fetchedAt = row.fetchedAt;
-  const ageMs = Date.now() - fetchedAt.getTime();
-
   const mmStats: DirectoryMmStats | null = row.mmStatsJson
     ? (row.mmStatsJson as unknown as DirectoryMmStats)
     : null;
@@ -240,7 +515,6 @@ export async function getCachedPlayerSnapshot(uuidRaw: string): Promise<Director
 const playerRefreshInFlight = new Map<string, Promise<DirectoryPlayerSnapshot>>();
 
 function playerLockKey(uuidNoDashLower: string) {
-  // Keep key1 stable; key2 is a cheap deterministic 32-bit hash.
   let h = 0;
   for (let i = 0; i < uuidNoDashLower.length; i++) {
     h = (h * 31 + uuidNoDashLower.charCodeAt(i)) | 0;
@@ -249,10 +523,12 @@ function playerLockKey(uuidNoDashLower: string) {
 }
 
 async function refreshPlayerSnapshotFromHypixelImpl(
+  
   uuidRaw: string,
   opts?: { player?: any; guild?: any },
 ): Promise<DirectoryPlayerSnapshot> {
   const uuid = normalizeUuid(uuidRaw);
+  // console.log("REFRESH CALLED FOR:", uuidRaw);
 
   type HypixelPlayerRes = { success?: boolean; player?: any };
   type HypixelGuildRes = { success?: boolean; guild?: any };
@@ -274,10 +550,10 @@ async function refreshPlayerSnapshotFromHypixelImpl(
 
   const player = playerPayload;
   const guild = guildPayload;
+  // console.log("MM keys:", Object.keys(player.stats?.MurderMystery || {}));
 
   let mmStats = extractMmStatsFromPlayer(player);
 
-  // Attach guild tag/colour if available so the card can show [TAG] and guild colour.
   if (mmStats && guild && typeof guild === "object") {
     if (typeof (guild as any).tag === "string") {
       (mmStats as any).guildTag = (guild as any).tag as string;
@@ -315,11 +591,6 @@ async function refreshPlayerSnapshotFromHypixelImpl(
   } satisfies DirectoryPlayerSnapshot;
 }
 
-// Force-refresh a player's snapshot from Hypixel and persist the result.
-//
-// This is used by maintainer/admin actions and should be safe to call from
-// multiple concurrent requests: we coalesce per-process and also guard with
-// a Postgres advisory lock across processes.
 export async function refreshPlayerSnapshotFromHypixel(
   uuidRaw: string,
   opts?: { player?: any; guild?: any },
@@ -338,16 +609,13 @@ export async function refreshPlayerSnapshotFromHypixel(
 
     if (locked.ran && locked.value) return locked.value;
 
-    // Another process is refreshing; return cached data if available.
     const cached = await getCachedPlayerSnapshot(uuidRaw);
     if (cached) return cached;
 
-    // If we can't read a cache yet, wait briefly and retry once.
     await new Promise((r) => setTimeout(r, 500));
     const cached2 = await getCachedPlayerSnapshot(uuidRaw);
     if (cached2) return cached2;
 
-    // Worst case: proceed without lock. This should be rare.
     return await refreshPlayerSnapshotFromHypixelImpl(uuidRaw, opts);
   })();
 
@@ -356,8 +624,6 @@ export async function refreshPlayerSnapshotFromHypixel(
   return p;
 }
 
-// Helper used by any backend consumer that wants "fresh enough" data
-// without forcing a network call if the cache is still warm.
 export async function getOrRefreshPlayerSnapshot(
   uuidRaw: string,
 ): Promise<DirectoryPlayerSnapshot | null> {
@@ -369,7 +635,6 @@ export async function getOrRefreshPlayerSnapshot(
   try {
     return await refreshPlayerSnapshotFromHypixel(uuidRaw);
   } catch (err) {
-    // If refreshing fails, fall back to stale data if we have it.
     if (existing) return existing;
     throw err;
   }


### PR DESCRIPTION
## Changes
Added extraction and display for mode-specific stats across all game modes.

### Backend (`hypixel-player-stats.ts`)
- Added `MurderMysteryClassicStats` type for Classic mode
- Added `MurderMysteryDoubleUpStats` type for Double Up mode
- Added `AssassinsStats` type for Assassins
- Added `InfectionStats` type for Infection
- Extended `DirectoryMmStats` to include all new mode fields
- Implemented extraction functions for each game mode

### Frontend (`MMIDDirectoryMasterDetail.tsx`)
- Updated tabs to display mode-specific data instead of placeholder text
- Added conditional rendering for each game mode tab
- Shows "No data available" message when player hasn't played a mode
- Design consistent with the overall tab